### PR TITLE
Fix typos in styles and database schema

### DIFF
--- a/finance-ai/app/globals.css
+++ b/finance-ai/app/globals.css
@@ -49,7 +49,8 @@ body {
     --popover: 0 0% 9%;
     --popover-foreground: 0 0% 95%;
     --primary: 102 59% 44%; /* Adjusted for #55B02E */
-    --primary-foreground: 0 0 100% --secondary: 240 3.7% 15.9%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 240 3.7% 15.9%;
     --secondary-foreground: 0 0 100%;
     --muted: 0 0% 15%;
     --muted-foreground: 240 5% 64.9%;

--- a/finance-ai/prisma/migrations/20241105234640_init_db/migration.sql
+++ b/finance-ai/prisma/migrations/20241105234640_init_db/migration.sql
@@ -13,7 +13,7 @@ CREATE TABLE "Transaction" (
     "name" TEXT NOT NULL,
     "type" "TransactionType" NOT NULL,
     "amount" DECIMAL(10,2) NOT NULL,
-    "categoriy" "TransactionCategory" NOT NULL,
+    "category" "TransactionCategory" NOT NULL,
     "paymentMethods" "TransactionPaymentMethod" NOT NULL,
     "date" TIMESTAMP(3) NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/finance-ai/prisma/schema.prisma
+++ b/finance-ai/prisma/schema.prisma
@@ -18,7 +18,7 @@ model Transaction {
   name           String
   type           TransactionType
   amount         Decimal                  @db.Decimal(10, 2)
-  categoriy      TransactionCategory
+  category       TransactionCategory
   paymentMethods TransactionPaymentMethod
   date           DateTime
   createdAt      DateTime                 @default(now())


### PR DESCRIPTION
## Summary
- correct typo in Transaction model field name
- split variable declarations in CSS theme

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687054016b908330a136d1d94a9b78bc